### PR TITLE
Add step to create .env.production in CI workflow

### DIFF
--- a/.github/workflows/next.yml
+++ b/.github/workflows/next.yml
@@ -73,6 +73,8 @@ jobs:
             ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json', '**/yarn.lock') }}-
       - name: Install dependencies
         run: ${{ steps.detect-package-manager.outputs.manager }} ${{ steps.detect-package-manager.outputs.command }}
+      - name: Create env file
+        run: echo "NEXT_PUBLIC_API_URL=${{ secrets.NEXT_PUBLIC_API_URL }}" >> .env.production
       - name: Build with Next.js
         run: ${{ steps.detect-package-manager.outputs.runner }} next build
       - name: Upload artifact


### PR DESCRIPTION
A new step was added to the GitHub Actions workflow to create a .env.production file with the NEXT_PUBLIC_API_URL secret before building the Next.js app. This ensures the environment variable is available during the build process.